### PR TITLE
Bold table header rows. Close Issue #94

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -3640,13 +3640,13 @@ CESR support for the ACDC protocol includes conveying sections of an ACDC as CES
 
 |Ilk|Name|Description|
 |---|---|---|
-|     |      | Registry TEL Message Types|
+|     |        | **Registry TEL Message Types** |
 | rip | Registry Inception | Initialize blindable state ACDC Registry |
 | upd | Update | Update transaction state of blindable state ACDC Registry |
-|     |        | ACDC Message |
+|     |        | **ACDC Message** |
 |     | ACDC | Default ACDC without Message type (ilk), `t` field |
 | acd | ACDC | With Message type (ilk), `t` field |
-|     |        | ACDC Section Message types |
+|     |        | **ACDC Section Message types** |
 | sch | Schema | Schema section Message |
 | att | Attribute | Attribute section Message |
 | agg | Aggregate | Attribute aggregate section Message |


### PR DESCRIPTION
Close #94 

I bolded the header rows of the [Section 16.7.1](https://trustoverip.github.io/tswg-acdc-specification/#message-type-table). 

Note: bold texts do not seem to be rendered properly, so we can't really see that they are rendered anyway. 