### PR TITLE
fix: rapid scroll bug fixed by v1.6.21 of Spec Up T

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "spec-up-t": "^1.6.0"
+        "spec-up-t": "^1.6.21"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -870,14 +870,49 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/b4a": {
@@ -1598,9 +1633,9 @@
       "license": "MIT"
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -1650,9 +1685,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -2135,9 +2170,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2198,9 +2233,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -3169,9 +3204,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -4598,22 +4633,22 @@
       }
     },
     "node_modules/spec-up-t": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/spec-up-t/-/spec-up-t-1.6.9.tgz",
-      "integrity": "sha512-Y28i6xcVzVViqDlM8BBvOVv/MlVgg9gYu/cZhtS3pM2KSDEO9RAXhS1sUdQHAeIH0NCpx2oywRxUWm5FUlGiZw==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/spec-up-t/-/spec-up-t-1.6.21.tgz",
+      "integrity": "sha512-G50C6KYZcop/pQATeVV6djydToTnnxfAYWiTQY72VeCHPg9UFelfZ+k5Gqj8OJPk2eEy5nVmtUX7N3D74hBoWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@octokit/plugin-throttling": "^9.4.0",
+        "@octokit/plugin-throttling": "^9.6.1",
         "@traptitech/markdown-it-katex": "^3.3.0",
-        "axios": "^1.7.7",
+        "axios": "^1.15.0",
         "chalk": "^4.1.2",
-        "cheerio": "^1.1.2",
-        "dedent": "^1.5.3",
-        "diff": "^8.0.3",
+        "cheerio": "^1.2.0",
+        "dedent": "^1.7.2",
+        "diff": "^8.0.4",
         "docx": "^8.5.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "^16.6.1",
         "find-pkg-dir": "^2.0.0",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.4",
         "gulp": "^5.0.1",
         "gulp-clean-css": "4.3.0",
         "gulp-concat": "2.6.1",
@@ -4638,13 +4673,13 @@
         "markdown-it-textual-uml": "^0.1.3",
         "markdown-it-toc-and-anchor": "^4.2.0",
         "merge-stream": "^2.0.0",
-        "octokit": "^4.1.0",
+        "octokit": "^4.1.4",
         "pdf-lib": "^1.17.1",
         "pkg-dir": "^8.0.0",
         "prismjs": "^1.24.0",
         "puppeteer": "^23.2.1",
         "readline-sync": "^1.4.10",
-        "spec-up-t-healthcheck": "^1.0.0",
+        "spec-up-t-healthcheck": "^1.1.2",
         "yargs": "^17.7.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Technical specification drafting tool that generates rich specification documents from markdown.",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "spec-up-t": "^1.6.0"
+    "spec-up-t": "^1.6.21"
   },
   "author": "Daniel Buchner",
   "repository": {


### PR DESCRIPTION
Closes #195.

Updates `spec-up-t` from `^1.6.0` to `^1.6.21` and refreshes the npm lockfile, matching trustoverip/kswg-did-method-webs-specification#207.

Validation:
- `npm ci`
- `npm ls spec-up-t --depth=0`
- `npm run render`
