### PR TITLE
(on v1.1) Restrict `-` and bare `_` in ACDC field labels

### DIFF
--- a/spec/spec-body.md
+++ b/spec/spec-body.md
@@ -38,7 +38,7 @@ The following fields are REQUIRED `[v, d, i, s]` i.e. they MUST appear in any AC
 ### Other Reserved Fields
 
 The following table defines non-top-level fields whose labels MUST be reserved.
-These MAY appear at other levels besides the top-level of an ACDC.
+Most of these MAY appear at other levels besides the top-level of an ACDC.
 
 | Label | Title | Description |
 |:-:|:--|:--|
@@ -52,10 +52,19 @@ These MAY appear at other levels besides the top-level of an ACDC.
 |`w`| Weight| Edge weight property that enables default property for directed weighted edges and operators on directed weighted edges.|
 |`l`| Legal Language| Text of Ricardian contract clause.|
 |`dt`| Datetime | Context-dependent ISO datetime string |
+|`_`| DAG Hop | Virtual label that denotes the traversal (hop) from an Edge in the near-side ACDC to the top level of the far-side ACDC referenced by that Edge's Node, `n`, field. It appears only in an expansion of a DAG of chained ACDCs and MUST NOT appear as a field label in an ACDC (see [Field Label Restrictions](#field-label-restrictions)).|
 
 ### Compact Labels
 
 The primary field labels are compact in that they MUST use only one or at most two characters. ACDCs are meant to support resource-constrained applications such as supply chain or IoT (Internet of Things) applications. Compact labels better support resource-constrained applications in general. With compact labels, the over-the-wire verifiable signed serialization consumes a minimum amount of bandwidth. Nevertheless, without loss of generality, a one-to-one normative semantic overlay using more verbose expressive field labels may be applied to the normative compact labels after verification of the over-the-wire serialization. This approach better supports bandwidth and storage constraints on transmission while not precluding any later semantic post-processing. This is a well-known design pattern for resource-constrained applications.
+
+### Field Label Restrictions
+
+Field labels serve as the components of the paths that reference parts of an ACDC or parts of a DAG of chained ACDCs. The components of such a path are separated by the path delimiter, `/`. When a path is serialized compactly as a CESR primitive, the path delimiter, `/`, is replaced by the character `-` so that the resultant serialization consists solely of [Base64](#RFC4648) characters and therefore incurs no expansion of non-Base64 characters into their Base64 equivalents. Consequently, a field label in an ACDC MUST NOT contain the character `-`. This is not a burdensome restriction because most programming languages do not allow `-` in an attribute name. Although a field map key MAY in general be any string, by convention a key that contains `-` is both less readable and less compactly serialized in CESR, so there is good reason to avoid it.
+
+Because `-` is thereby reserved as the compactly serialized path delimiter, the only remaining Base64 character available to denote a hop across an Edge from one ACDC to another is `_`. The field label `_` MUST therefore be reserved as a virtual path component that denotes such a hop, that is, the traversal from an Edge in the near-side ACDC to the top level of the far-side ACDC referenced by that Edge's Node, `n`, field. Consequently, a field in an ACDC MUST NOT be labeled with a single `_` character. The `_` character MAY appear within a longer field label, such as `first_name`. To clarify, only a field label consisting of exactly one `_` character is forbidden. This is not a burdensome restriction because the convention in most programming languages is to use a lone `_` as the name of an ignored variable, and an ACDC has little reason to include a field whose value is meant to be ignored.
+
+To elaborate, the `_` label appears only in an expansion of a DAG of chained ACDCs into a single field map. In such an expansion, each Edge block gains an additional field whose label is `_` and whose value is the subgraph contributed by the far-side ACDC referenced by that Edge's Node, `n`, field. Because the expansion supplies a field labeled `_` at each hop, a path that traverses the DAG needs no path delimiter other than `/`, and extraction of a value from the expansion uses the same path syntax as extraction of a value from within a single ACDC.
 
 ### Version String Field
 


### PR DESCRIPTION
I raised this PR to capture a decision about path serialization from [WebOfTrust/keripy discussion #1549](https://github.com/WebOfTrust/keripy/discussions/1549). See Sam's comment of 2026-08-02.

1. `-` MUST NOT appear in a field label

A path is serialized compactly as a CESR primitive by replacing the `/` delimiter with `-`, so
that the result is pure Base64 and needs no expansion of non-Base64 characters into their
Base64 equivalents. That only works if `-` never appears inside a path component, and path
components are field labels.

From the discussion:

> We support this by forbidding `-` as a character in any valid path component name and then
> serialized `/` the path delimiter as `-`. The resultant path is compact Base64 (no expansion
> from non-base64 to their Base64 equivalent). Forbidding `-` as character in a path component
> name is not a problematic limitation because attribute names in most languages cannot use
> `-`.

2. A bare `_` MUST NOT be a field label; it is reserved as the DAG-hop path component

With `-` consumed as the serialized delimiter, `_` is the only Base64 character left with which
to denote a hop across an Edge from the near-side ACDC to the far side. Rather than make it a
second delimiter, the discussion makes it a *virtual path component*: in an expansion of a DAG
of chained ACDCs, each Edge block gains a field labeled `_` whose value is the far-side ACDC's
subgraph. A path then traverses the DAG using nothing but ordinary `/`-separated components.

From the discussion:

> But if instead of treating `_` as a path delimiter we treated it as a virtual special path
> component. This path component represents abstraction the ACDC DAG Hop. The advantage of this
> is that we could then do an expansion of a full DAG of ACDCs into a single field map where the
> edge block has a special added field in the expansion. That field label is `_` and the value
> of that field is the subgraph of the chained ACDC pointed to by the associated edge.

and on the scope of the restriction:

> But we could restrict attribute name and dict Keys's to not use a single `_` as the full name.
> This is a much less problematic restriction since the convention for variable/attribute names
> that are a single `_` is to treat them as ignored variables.

`_` inside a longer label, such as `first_name`, stays legal. Only a label that is exactly one
`_` is forbidden.

`spec/spec-body.md` changed:

- New `### Field Label Restrictions` subsection (`spec/spec-body.md:61`) under `## ACDC Structure`, placed after
  `### Compact Labels` and before `### Version String Field`. Three paragraphs: the `-`
  restriction and its Base64 rationale; the `_` reservation and the narrowness of it; and what
  the `_` field means in a DAG expansion.
- One new row (`spec/spec-body.md:55`) in the existing `### Other Reserved Fields` table for `_` ("DAG Hop"), noting that
  it appears only in a DAG expansion and MUST NOT appear as a field label in an ACDC.
- That table's preamble (`spec/spec-body.md:41`) softened from "These MAY appear at other
  levels besides the top-level of an ACDC" to "Most of these MAY appear...", since `_` never
  appears in an ACDC at any level.

No other section was touched. `docs/index.html` is generated output and was not regenerated in
this commit.

Restriction 1 codifies behavior that already exists at keripy HEAD; restriction 2 is new.

- `src/keri/help/helping.py:469` — `PATHREX = rb'^[a-zA-Z0-9_]*$'`, with the comment
  "excluding b'-' in part because '-' is path separator when in B64".
- `src/keri/core/coring.py:3102-3105` — a Pather part that fails that regex raises
  `InvalidValueError` when the Pather is `pathive`; otherwise the path falls back to
  non-compact Bytes encoding. So today `-` costs you the compact form; the spec change makes
  the compact form always available.
- `src/keri/core/coring.py:3021-3025` — the `Pather` docstring already documents `-` as the
  compact path separator.

Nothing in keripy currently reserves a bare `_` label.

I'm pretty sure this is fully compatible with the current spec in other places. I checked for two hazards:

- No field label anywhere in `spec/spec-body.md`, `spec/spec-head.md`, or
  `spec/terms-definitions/` contains `-`. (Regex over JSON-style `"key":` occurrences returns
  zero hits.) The `author-i` label that keripy issue #1520 mentioned is not present in the spec
  at `upstream/v1.1`. The only backticked hyphenated token in the body is `date-time` at
  `spec/spec-body.md:107`, which is JSON Schema's `format` value, not a field label.
- No field is labeled `_`.

So no worked example needed fixing, and the commit is purely additive.

**`dp` is not in the spec yet.** There is no mention of `dp`, disclosure paths, Pather, or SAD
path syntax anywhere in the spec source. That shaped the change: the new section has to define
the path context it depends on in one sentence, self-contained, rather than cross-referencing a
section that does not exist. When `dp` does become part of the spec, that section should link back to Field Label Restrictions.

I made these judgment calls:

1. **A new `###` subsection rather than a sentence bolted onto `### Compact Labels`.** Compact
   Labels is specifically about the reserved primary labels being one or two characters. These
   two restrictions bind *all* labels, including application-defined attribute labels, so
   folding them in there would have been misleading. Placing the new section after Compact
   Labels keeps the three existing label subsections in their current order and untouched.

2. **Adding a `_` row to the Other Reserved Fields table.** Mild tension: that table's preamble
   says its labels "MAY appear at other levels besides the top-level of an ACDC," whereas `_`
   never appears in an ACDC at all — only in a DAG expansion. I added the row anyway, because
   that table is where a reader goes to find out which labels are spoken for, and the row's
   description states the restriction explicitly, and I softened the preamble to "Most of
   these MAY appear..." rather than leaving the two in conflict. If a reviewer objects,
   dropping the row leaves the normative content intact in the prose section.

3. **No worked example of the expansion form.** The discussion has one (an Edge block with a `_`
   field carrying the Research Report ACDC), and the spec is example-heavy, so one could be
   argued for. I left it out: the spec's examples carry real SAIDs that are regenerated from the
   keripy reference implementation, and inventing an expansion example here would either need
   SAID work or introduce an example inconsistent with the rest of Annex "Working ACDC Examples."
   Better attached to the `dp` section when that lands.

4. **Cited RFC4648 as `[Base64](#RFC4648)`** to match the two existing in-text citations of it
   (`spec/spec-body.md:2150` and `:3356`). It is already in the Normative section of the
   bibliography, so no bibliography change was needed.

## Adjacent observations, not addressed here

- The `### Other Reserved Fields` table has a duplicate `dt` row (`spec/spec-body.md:49` and `:54`), pre-existing. Left alone to keep this PR single-purpose.
- The Schema section's SAID field label is `$id` (`spec/spec-body.md:193`), and `$` is not a
  Base64 character either. It does not break restriction 1 as written, and per discussion
  #1549 the schema section is always disclosed so no disclosure path descends into it — but
  that exemption is stated in the discussion, not in the spec, and `$id` could never be a
  Pather component regardless. Worth pinning on #1549 and then stating wherever path scope
  gets defined, rather than legislating it here.
- Discussion #1549's own DAG-absolute examples use `/e/report/...` while the Transcript ACDC in
  the same discussion labels that edge group `reports`. Cosmetic inconsistency in the
  discussion, not in the spec.

---

Analysis and drafting assisted by [Claude Code](https://claude.com/claude-code); reviewed and authored by @dhh1128.